### PR TITLE
Update deploy cloud run service

### DIFF
--- a/.github/workflows/deploy-cloud-run-service.yml
+++ b/.github/workflows/deploy-cloud-run-service.yml
@@ -161,8 +161,8 @@ jobs:
       - name: Show deployed service URL
         run: echo "${{ steps.deploy-service.outputs.url }}"
 
-      - name: Create topic and subscription
-        uses: octue/create-push-subscription@0.2.2
+      - name: Create service revision push subscription
+        uses: octue/create-push-subscription@0.4.0
         with:
           project_name: ${{ needs.info.outputs.gcp_project_name }}
           service_namespace: ${{ needs.info.outputs.gcp_resource_affix }}

--- a/.github/workflows/deploy-cloud-run-service.yml
+++ b/.github/workflows/deploy-cloud-run-service.yml
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/deploy-cloud-run-service.yml
+++ b/.github/workflows/deploy-cloud-run-service.yml
@@ -65,21 +65,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install poetry
         uses: snok/install-poetry@v1
 
       - name: Get deployment info
         id: get-deployment-info
-        uses: octue/get-deployment-info@0.2.1
+        uses: octue/get-deployment-info@0.3.2
         with:
           gcp_project_name: ${{ inputs.gcp_project_name }}
           gcp_project_number: ${{ inputs.gcp_project_number }}
           gcp_region: ${{ inputs.gcp_region }}
           gcp_resource_affix: ${{ inputs.gcp_resource_affix }}
           gcp_service_name: ${{ inputs.gcp_service_name }}
-          gcp_environment: ${{ inputs.gcp_environment }}
 
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ jobs:
       gcp_region: europe-west3
       gcp_resource_affix: my-resource-affix
       server_name: server
+      settings_module: server.settings
+      database_name: primary
 
   ...      
 ```


### PR DESCRIPTION
# Contents
**IMPORTANT:** There is 1 breaking change.

### Enhancements
- 💥 **BREAKING CHANGE:** Use `octue/create-push-subscription@0.4.0` in `deploy-cloud-run-service` workflow to allow deployment of service revisions in single-topic workspaces
- Use `octue/get-deployment-info@0.3.2` in `deploy-cloud-run-service` workflow to enable branch deployments by default

# Upgrade instructions
Ensure your Octue service is using `octue` version `0.53.0`+ .