### PR TITLE
Use `python3.11` dockerfile for data services by default

### DIFF
--- a/.github/workflows/deploy-cloud-run-service.yml
+++ b/.github/workflows/deploy-cloud-run-service.yml
@@ -27,12 +27,13 @@ on:
       dockerfile_url:
         type: string
         required: false
-        default: 'https://raw.githubusercontent.com/octue/octue-sdk-python/main/octue/cloud/deployment/google/cloud_run/Dockerfile'
+        default: 'https://raw.githubusercontent.com/octue/octue-sdk-python/main/octue/cloud/deployment/google/cloud_run/Dockerfile-python311'
+        description: Use the default Octue data service dockerfile (based on python3.11).
       local_dockerfile:
         type: string
         required: false
         default: ''
-        description: Use a local Dockerfile at this path e.g. './Dockerfile'. Overrides the `dockerfile_url` input.
+        description: Use a local Dockerfile at this path e.g. './Dockerfile'. Not used by default; overrides the `dockerfile_url` input.
       service_registry_endpoint:
         type: string
         required: false

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ jobs:
 ### Deploying a Cloud Run Octue service
 This workflow builds and deploys a revision of a dockerised Octue service to Google Cloud Run, storing the image in 
 Google Cloud Artifact Registry. A Google Pub/Sub push subscription is created for the revision and, if given, it's 
-registered with a service registry. The Dockerfile can be located locally or at a URL.
+registered with a service registry. By default, the default Octue data service `Dockerfile` is used (based on 
+python3.11) but any `Dockerfile` can be provided either locally or from a URL.
 
 **Example usage**
 


### PR DESCRIPTION
# Contents

### Enhancements
- Use `python3.11`-based dockerfile for deploying data services by default
